### PR TITLE
Issue #QA Issue : feat: no of option configuration

### DIFF
--- a/projects/collection-editor-library/src/lib/components/editor/editor.component.spec.data.ts
+++ b/projects/collection-editor-library/src/lib/components/editor/editor.component.spec.data.ts
@@ -509,6 +509,11 @@ export const hirearchyGet = {
 export const categoryDefinition = {
   result: {
     objectCategoryDefinition: {
+      objectMetadata: {
+        config: {
+          maximumOptions:20
+        },
+      },
       forms: {
         unitMetadata: {
           properties: { code: "name", editable: true },

--- a/projects/collection-editor-library/src/lib/components/editor/editor.component.ts
+++ b/projects/collection-editor-library/src/lib/components/editor/editor.component.ts
@@ -911,6 +911,7 @@ export class EditorComponent implements OnInit, OnDestroy, AfterViewInit {
 
       const catMetaData = _.get(selectedtemplateDetails, 'objectMetadata');
       this.sourcingSettings = _.get(catMetaData, 'config.sourcingSettings') || {};
+      !_.isUndefined(this.editorConfig.config.renderTaxonomy) ? (this.questionComponentInput.config ={maximumOptions:_.get(catMetaData, 'config.maximumOptions')}) : '' ;
       if (!_.has(this.sourcingSettings, 'enforceCorrectAnswer')) {
         this.sourcingSettings.enforceCorrectAnswer = true;
       }

--- a/projects/collection-editor-library/src/lib/components/editor/editor.component.ts
+++ b/projects/collection-editor-library/src/lib/components/editor/editor.component.ts
@@ -986,6 +986,7 @@ export class EditorComponent implements OnInit, OnDestroy, AfterViewInit {
         const selectedtemplateDetails = res.result.objectCategoryDefinition;
         this.editorService.selectedChildren['label']=selectedtemplateDetails.label;
         const selectedTemplateFormFields = _.get(selectedtemplateDetails, 'forms.create.properties');
+        this.questionComponentInput.config ={maximumOptions:_.get(selectedtemplateDetails, 'objectMetadata.config.maximumOptions')}
         if (!_.isEmpty(selectedTemplateFormFields)) {
           const questionCategoryConfig = selectedTemplateFormFields;
           questionCategoryConfig.forEach(field => {

--- a/projects/collection-editor-library/src/lib/components/options/options.component.html
+++ b/projects/collection-editor-library/src/lib/components/options/options.component.html
@@ -52,7 +52,7 @@
       </div>
     </div>
     <div class="d-flex">
-      <button *ngIf="editorState.options.length < 4"
+      <button *ngIf="editorState.options.length < editorState.maximumOptions"
         class="sb-btn sb-btn-outline-primary sb-btn-xs sb-left-icon-btn text-inherit b-0 bg-none no-hover p-0 mb-10 mt-10"
         (click)="editorState.addOptions();editorDataHandler($event);"
         libTelemetryInteract

--- a/projects/collection-editor-library/src/lib/components/question/question.component.ts
+++ b/projects/collection-editor-library/src/lib/components/question/question.component.ts
@@ -244,13 +244,14 @@ export class QuestionComponent implements OnInit, AfterViewInit, OnDestroy {
                 this.scoreMapping = _.get(responseDeclaration, 'response1.mapping');
                 const templateId = this.questionMetaData.templateId;
                 const numberOfOptions = this.questionMetaData?.editorState?.options?.length || 0;
+                const maximumOptions = _.get(this.questionInput, 'config.maximumOptions');
                 this.editorService.optionsLength = numberOfOptions;
                 const options = _.map(this.questionMetaData?.editorState?.options, option => ({ body: option.value.body }));
                 const question = this.questionMetaData?.editorState?.question;
                 const interactions = this.questionMetaData?.interactions;
                 this.editorState = new McqForm({
                   question, options, answer: _.get(responseDeclaration, 'response1.correctResponse.value')
-                }, { templateId, numberOfOptions });
+                }, { templateId, numberOfOptions,maximumOptions });
                 this.editorState.solutions = this.questionMetaData?.editorState?.solutions;
                 this.editorState.interactions = interactions;
               }

--- a/projects/collection-editor-library/src/lib/components/question/question.component.ts
+++ b/projects/collection-editor-library/src/lib/components/question/question.component.ts
@@ -302,7 +302,7 @@ export class QuestionComponent implements OnInit, AfterViewInit, OnDestroy {
           this.editorState = { ...editorState };
         }
         else if (this.questionInteractionType === 'choice') {
-          this.editorState = new McqForm({ question: '', options: [] }, {numberOfOptions: _.get(this.questionInput, 'config.numberOfOptions')});
+          this.editorState = new McqForm({ question: '', options: [] }, { numberOfOptions: _.get(this.questionInput, 'config.numberOfOptions'), maximumOptions: _.get(this.questionInput, 'config.maximumOptions') });
         }
         /** for observation and survey to show hint,tip,dependent question option. */
         if(!_.isUndefined(this.editorService?.editorConfig?.config?.renderTaxonomy)){
@@ -782,7 +782,7 @@ export class QuestionComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     metadata = _.merge(metadata, _.pickBy(this.childFormData, _.identity));
     // tslint:disable-next-line:max-line-length
-    return _.omit(metadata, ['question', 'numberOfOptions', 'options', 'allowMultiSelect', 'showEvidence', 'evidenceMimeType', 'showRemarks', 'markAsNotMandatory', 'leftAnchor', 'rightAnchor', 'step', 'numberOnly', 'characterLimit', 'dateFormat', 'autoCapture', 'remarksLimit']);
+    return _.omit(metadata, ['question', 'numberOfOptions', 'options', 'allowMultiSelect', 'showEvidence', 'evidenceMimeType', 'showRemarks', 'markAsNotMandatory', 'leftAnchor', 'rightAnchor', 'step', 'numberOnly', 'characterLimit', 'dateFormat', 'autoCapture', 'remarksLimit','maximumOptions']);
   }
 
   getResponseDeclaration(type) {

--- a/projects/collection-editor-library/src/lib/interfaces/McqForm.ts
+++ b/projects/collection-editor-library/src/lib/interfaces/McqForm.ts
@@ -15,6 +15,7 @@ export interface McqData {
 export interface McqConfig {
   templateId?: string;
   numberOfOptions?: number;
+  maximumOptions?:number;
 }
 
 export class McqForm {
@@ -26,7 +27,8 @@ export class McqForm {
   public bloomsLevel;
   public maxScore;
   public numberOfOptions;
-  constructor({question, options, answer, learningOutcome, bloomsLevel, maxScore}: McqData, {templateId, numberOfOptions}: McqConfig) {
+  public maximumOptions;
+  constructor({question, options, answer, learningOutcome, bloomsLevel, maxScore}: McqData, {templateId, numberOfOptions, maximumOptions}: McqConfig) {
     this.question = question;
     this.options = options || [];
     this.templateId = templateId;
@@ -35,6 +37,7 @@ export class McqForm {
     this.bloomsLevel = bloomsLevel;
     this.maxScore = maxScore;
     this.numberOfOptions = numberOfOptions || 2;
+    this.maximumOptions = maximumOptions || 4
     if (!this.options || !this.options.length) {
       _.times(this.numberOfOptions, index => this.options.push(new McqOptions('')));
     }


### PR DESCRIPTION
**Issue** - For Observation without Rubrics and Survey **MCQ** question there will be minimum 2 option and maximum no of option can be vary, 
current for **MCQ** question it minimum 2 option and maximum 4 option;

 **Fix** -  we have configured the maximum no of option in **MCQ Category Definition** under the key name **maximumOptions** using that we have configured the in **McqForm**